### PR TITLE
Bodge in ability to manually specify parameters

### DIFF
--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -262,6 +262,11 @@ class ResourceSwaggerMapping(object):
                                     description=force_text(schema_field['help_text']),
                                 ))
 
+        # Manually extend with extra_attrs
+        if hasattr(self.resource._meta, 'extra_attrs'):
+            for extra_attr in self.resource._meta.extra_attrs:
+                parameters.append(extra_attr)
+
         return parameters
 
     def build_parameter_for_object(self, method='get'):


### PR DESCRIPTION
A new `extra_attrs` field is tracked in schema allowing users to
manually provide parameters to the resource.

Format should match the result of `build_parameter`:
```
parameter = {
    'paramType': type as string,
    'name': name as string,
    'dataType': type as string,
    'required': attr is required as boolean,
    'description': description,
}
```